### PR TITLE
Centralize constants

### DIFF
--- a/admin/add_user_to_all_workflows.rb
+++ b/admin/add_user_to_all_workflows.rb
@@ -1,5 +1,6 @@
 require 'dspace'
 require "highline/import"
+require 'cli/dconstants'
 
 
 DSpace.load
@@ -13,7 +14,7 @@ def doit
   if not p then
     puts "no such account #{netid}"
   else
-    DSpace.login ENV["USER"]
+    DSpace.login DConstants::LOGIN
     create_tasks p
     if "Y" == ask( "Commit changes: Yes or No (Y/N) ") then
       DSpace.commit

--- a/cli/dconstants.rb
+++ b/cli/dconstants.rb
@@ -1,0 +1,13 @@
+##
+# Useful Princeton-specific constants
+class DConstants
+	LOGIN = ENV['USER'] # default login
+	SENIOR_THESIS_HANDLE = '88435/dsp019c67wm88m' # handle for senior thesis collection
+	PPPL_HANDLE = '88435/dsp01pz50gz45g'
+	SUBMITTERS_NAME = 'Lib_DigPubs_Submitters'
+	DEFAULT_YEAR = 2018
+end
+
+
+# Go back to...
+#  -- library/list.rb

--- a/collection/add_workflow_groups.rb
+++ b/collection/add_workflow_groups.rb
@@ -4,6 +4,8 @@ require "highline/import"
 require 'dspace'
 require 'cli/dcommunity'
 require 'cli/dcollection'
+require 'cli/dconstants'
+
 options = {}
 parser = OptionParser.new do |opts|
   opts.banner = "Usage: #{__FILE__} handle (step_1, step_2, step_3, submit)*"
@@ -14,7 +16,7 @@ begin
   raise "must give at collection/community parameter and at least one workflow step" if ARGV.length < 2
 
   DSpace.load
-  DSpace.login ENV['USER']
+  DSpace.login DConstants::LOGIN
   handle = ARGV.shift
   dso = DSpace.create(DSpace.fromString(handle))
   ARGV.each do |step|

--- a/community/find_or_create_collections.rb
+++ b/community/find_or_create_collections.rb
@@ -3,6 +3,7 @@ require 'optparse'
 require "highline/import"
 require 'dspace'
 require 'cli/dcommunity'
+require 'cli/dconstants'
 
 options = {}
 parser = OptionParser.new do |opts|
@@ -26,7 +27,7 @@ begin
   file_name = ARGV[1]
 
   DSpace.load
-  DSpace.login ENV['USER']
+  DSpace.login DConstants::LOGIN
   com = DSpace.create(DSpace.fromString(com_name))
 
   create_collections(com, file_name)

--- a/data/genTestData.rb
+++ b/data/genTestData.rb
@@ -3,6 +3,7 @@ require 'yaml';
 require 'faker';
 require 'dspace'
 require 'cli/ditem'
+require 'cli/dconstants'
 
 test_data_file = "data/genTestData.yml";
 
@@ -104,7 +105,7 @@ def doit(test_data_file)
   java_import org.dspace.content.Collection
   java_import org.dspace.content.Community
   java_import org.dspace.content.Item
-  DSpace.login(ENV['USER'])
+  DSpace.login DConstants::LOGIN
 
   generate(test_data_file)
   #DSpace.commit

--- a/library/list_submitters.rb
+++ b/library/list_submitters.rb
@@ -1,8 +1,10 @@
 #!/usr/bin/env jruby
 require 'dspace'
+require 'cli/dconstants'
+
 DSpace.load()
 
-name = "Lib_DigPubs_Submitters"
+name = DConstants::SUBMITTERS_NAME
 DGroup.find(name).getMembers.each do |m|
     puts [name, m.getEmail, m.canLogIn ? "Can Login" : "can't Login", m.getFullName].join "\t\t"
 end

--- a/library/pulibs.rb
+++ b/library/pulibs.rb
@@ -1,8 +1,9 @@
 #!/usr/bin/env jruby 
 require "highline/import"
 require "cli"
+require 'cli/dconstants'
 
-netid = 'monikam';
+netid = DConstants::LOGIN
 name = ask "Collection Name "; 
 name = name.strip; 
 

--- a/library/rm_submitter.rb
+++ b/library/rm_submitter.rb
@@ -1,11 +1,12 @@
 #!/usr/bin/env jruby
 require 'dspace'
 require "highline/import"
+require 'cli/dconstants'
 
 DSpace.load()
 DSpace.context_renew
 
-name = "Lib_DigPubs_Submitters"
+name = DConstants::SUBMITTERS_NAME
 group = DGroup.find(name)
 
 while (true) do
@@ -25,7 +26,7 @@ end
 
 yes = ask "Commit ? (Y/N)"
 if (yes[0] == 'Y') then
-    DSpace.login(ENV['USER'])
+    DSpace.login DConstants::LOGIN
     group.update()
     DSpace.commit
 end

--- a/netid/create.rb
+++ b/netid/create.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env jruby 
 require "highline/import"
+require 'cli/dconstants'
 require 'dspace'
 
 netid, first, last = ARGV
@@ -7,7 +8,7 @@ netid = ask("enter netid ") unless netid
 first = ask("first name  ") unless first
 last = ask("last name  ") unless last
 
-admin = ENV["USER"]
+admin = DConstants::LOGIN
 puts "Logging in as: #{admin}"
 
 DSpace.load

--- a/netid/password.rb
+++ b/netid/password.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env jruby 
 require "highline/import"
 require 'dspace'
+require 'cli/dconstants'
 
 netid, pwd = ARGV
 
@@ -9,7 +10,7 @@ if (netid.nil?) then
 end
 
 DSpace.load
-DSpace.login(ENV['USER']) 
+DSpace.login DConstants::LOGIN
 
 p = DEPerson.find(netid);
 raise "no such eperson" if p.nil?

--- a/pppl/groups.rb
+++ b/pppl/groups.rb
@@ -1,10 +1,11 @@
 require 'irb/completion'
 require 'dspace'
+require 'cli/dconstants'
 
 DSpace.load
 
 
-hdl = '88435/dsp01pz50gz45g'
+hdl = DConstants::PPPL_HANDLE
 def rec_members(group)
   gmems = group.getMemberGroups
   mems = gmems.collect{|g| g} + group.getMembers.collect {|m| m}

--- a/seniorTheses/changeClassYear.rb
+++ b/seniorTheses/changeClassYear.rb
@@ -1,9 +1,10 @@
 #!/usr/bin/env jruby  
 require "highline/import"
+require 'cli/dconstants'
 
 year = 2016
 schema, element, qualifier = ['pu', 'date', 'classyear']
-handle = '88435/dsp019c67wm88m'
+handle = DConstants::SENIOR_THESIS_HANDLE
 require 'dspace'
 DSpace.load
 

--- a/seniorTheses/checkPubPdfCoberpage.rb
+++ b/seniorTheses/checkPubPdfCoberpage.rb
@@ -1,8 +1,10 @@
 #!/usr/bin/env jruby  -I lib -I utils
 require 'dspace'
+require 'cli/dconstants'
+
 DSpace.load
 
-year = 2016
+year = DConstants::DEFAULT_YEAR
 items = DSpace.findByMetadataValue("pu.date.classyear", year, nil)
 
 hitems = items.select { |i| i.is_archived }

--- a/seniorTheses/cleanupAfterImport.rb
+++ b/seniorTheses/cleanupAfterImport.rb
@@ -1,10 +1,11 @@
 #!/usr/bin/env jruby
 require 'lumberjack'
+require 'cli/dconstants'
 
-$root = "88435/dsp019c67wm88m"
-$year = 2018
+$root = DConstants::SENIOR_THESIS_HANDLE
+$year = DConstants::DEFAULT_YEAR
 $year_metadata_field = "pu.date.classyear"
-$account = "monikam"
+$account = DConstants::LOGIN
 
 require 'dspace'
 require 'cli/ditem'

--- a/seniorTheses/createCollection.rb
+++ b/seniorTheses/createCollection.rb
@@ -1,11 +1,12 @@
 #!/usr/bin/env jruby 
 require "highline/import"
+require 'cli/dconstants'
 
-netid = 'monikam';
+netid = DConstants::LOGIN
 name = ask "Collection Name "; 
 name = name.strip;
 
-parent = '88435/dsp019c67wm88m'
+parent = DConstants::SENIOR_THESIS_HANDLE
 
 require 'dspace'
 DSpace.load()

--- a/seniorTheses/createCollections.rb
+++ b/seniorTheses/createCollections.rb
@@ -1,11 +1,12 @@
 #!/usr/bin/env jruby 
 require "highline/import"
+require 'cli/dconstants'
 
-netid = 'monikam';
+netid = DConstants::LOGIN
 name = ask "Collection Name "; 
 name = name.strip;
 
-parent = '88435/dsp019c67wm88m'
+parent = DConstants::SENIOR_THESIS_HANDLE
 
 require 'dspace'
 DSpace.load()

--- a/seniorTheses/list.rb
+++ b/seniorTheses/list.rb
@@ -1,11 +1,12 @@
 #!/usr/bin/env jruby  
 require 'xmlsimple'
 require 'dspace'
+require 'cli/dconstants'
 
 DSpace.load
 
 # dataspace
-fromString = '88435/dsp019c67wm88m'
+fromString = DConstants::SENIOR_THESIS_HANDLE
 
 com = DSpace.fromString(fromString)
 

--- a/seniorTheses/listEmbargoed.rb
+++ b/seniorTheses/listEmbargoed.rb
@@ -2,13 +2,15 @@
 require 'xmlsimple'
 require 'dspace'
 
+require 'cli/dconstants'
+
 #DSpace.load
 
 #postgres
 # fromString = "COMMUNITY.145"
 
 # dataspace
-fromString = '88435/dsp019c67wm88m'
+fromString = DConstants::SENIOR_THESIS_HANDLE
 
 com = DSpace.fromString(fromString)
 

--- a/seniorTheses/listMuddRestricted.rb
+++ b/seniorTheses/listMuddRestricted.rb
@@ -1,9 +1,11 @@
 #!/usr/bin/env jruby
 require 'dspace'
+require 'cli/dconstants'
+
 DSpace.load
 
 
-after_year = 2016
+after_year = DConstants::DEFAULT_YEAR
 
 puts ["Handle", "Year", "Mudd", "READ_group",  "Bitstream Name",].join "\t"
 

--- a/seniorTheses/listPuWalkn.rb
+++ b/seniorTheses/listPuWalkn.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env jruby  
 require 'xmlsimple'
 require 'dspace'
+require 'cli/dconstants'
 
 DSpace.load
 
@@ -8,7 +9,7 @@ DSpace.load
 # fromString = "COMMUNITY.145"
 
 # dataspace
-fromString = '88435/dsp019c67wm88m'
+fromString = DConstants::SENIOR_THESIS_HANDLE
 
 com = DSpace.fromString(fromString)
 

--- a/seniorTheses/list_xml.rb
+++ b/seniorTheses/list_xml.rb
@@ -2,10 +2,12 @@
 require 'xmlsimple'
 require 'dspace'
 
+require 'cli/dconstants'
+
 DSpace.load
 
 # dataspace
-fromString = '88435/dsp019c67wm88m'
+fromString = DConstants::SENIOR_THESIS_HANDLE
 com = DSpace.fromString(fromString)
 
 def all_year_hsh(year)

--- a/seniorTheses/mapToMultipleCollections.rb
+++ b/seniorTheses/mapToMultipleCollections.rb
@@ -1,15 +1,16 @@
 #!/usr/bin/env jruby
 require 'lumberjack'
+require 'cli/dconstants'
 
-account = "monikam"
+account = DConstants::LOGIN
 
 log_file = "#{ENV['DSPACE_HOME']}/log/map2Collections.log"
 logger = Lumberjack::Logger.new("#{log_file}", :buffer_size => 0) # Open a new log file with INFO level
 logger.level = :info
 puts "DEBUG logging action to  #{log_file}"
 
-root = "88435/dsp019c67wm88m"
-year = 2018
+root = DConstants::SENIOR_THESIS_HANDLE
+year = DConstants::DEFAULT_YEAR
 year_metadata_field = "pu.date.classyear"
 
 logger.info "START select #{year_metadata_field}=#{year} in #{root}"

--- a/seniorTheses/muddMetadataWalkinAccess.rb
+++ b/seniorTheses/muddMetadataWalkinAccess.rb
@@ -1,8 +1,9 @@
 #!/usr/bin/env jruby
 require "highline/import"
 require 'lumberjack'
+require 'cli/dconstants'
 
-account = "monikam"
+account = DConstants::LOGIN
 
 log_file = "#{ENV['DSPACE_HOME']}/log/muddWalking.log"
 

--- a/seniorTheses/newCollection.rb
+++ b/seniorTheses/newCollection.rb
@@ -1,14 +1,15 @@
 #!/usr/bin/env jruby 
 require "highline/import"
 require "cli"
+require 'cli/dconstants'
 
-netid = 'monikam';
+netid = DConstants::LOGIN
 name = ask "Collection Name "; 
 name = name.strip; 
 
 choices = [ {
-name: 'Princeton University Undergraduate Senior Theses',
-hdl: '88435/dsp019c67wm88m'
+    name: 'Princeton University Undergraduate Senior Theses',
+    hdl: DConstants::SENIOR_THESIS_HANDLE
 }]
 
 puts "Parent Collections"

--- a/seniorTheses/users.rb
+++ b/seniorTheses/users.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env jruby  
 require 'dspace'
+require 'cli/dconstants'
 
 DSpace.load
 
@@ -8,7 +9,7 @@ DSpace.load
 
 # dataspace
 
-fromString = '88435/dsp019c67wm88m'
+fromString = DConstants::SENIOR_THESIS_HANDLE
 
 com = DSpace.fromString(fromString)
 com.getCollections.collect do |col|

--- a/symplectic/add_group_members.rb
+++ b/symplectic/add_group_members.rb
@@ -1,9 +1,10 @@
 #!/usr/bin/env jruby
 require "highline/import"
 require 'dspace'
+require 'cli/dconstants'
 
 DSpace.load
-DSpace.login ENV['USER']
+DSpace.login DConstants::LOGIN
 puts "\n"
 
 filename = 'symplectic/group_members.txt'

--- a/symplectic/add_group_to_workflowsteps.rb
+++ b/symplectic/add_group_to_workflowsteps.rb
@@ -2,9 +2,10 @@
 require "highline/import"
 require 'dspace'
 require 'cli/dcollection'
+require 'cli/dconstants'
 
 DSpace.load
-DSpace.login ENV['USER']
+DSpace.login DConstants::LOGIN
 puts "\n"
 
 com_name =  'All'

--- a/symplectic/create_accounts.rb
+++ b/symplectic/create_accounts.rb
@@ -2,8 +2,10 @@
 require "highline/import"
 require 'dspace'
 
+require 'cli/dconstants'
+
 DSpace.load
-DSpace.login ENV['USER']
+DSpace.login DConstants::LOGIN
 puts "\n"
 
 filename = 'symplectic/accounts.txt'

--- a/symplectic/create_collections.rb
+++ b/symplectic/create_collections.rb
@@ -1,9 +1,10 @@
 #!/usr/bin/env jruby
 require "highline/import"
 require 'dspace'
+require 'cli/dconstants'
 
 DSpace.load
-DSpace.login ENV['USER']
+DSpace.login DConstants::LOGIN
 puts "\n"
 
 com_name =  'All'

--- a/symplectic/create_org_mapping.rb
+++ b/symplectic/create_org_mapping.rb
@@ -1,9 +1,10 @@
 #!/usr/bin/env jruby
 require "highline/import"
 require 'dspace'
+require 'cli/dconstants'
 
 DSpace.load
-DSpace.login ENV['USER']
+DSpace.login DConstants::LOGIN
 puts "\n"
 java_import org.dspace.storage.rdbms.DatabaseManager
 

--- a/symplectic/create_workflowsteps.rb
+++ b/symplectic/create_workflowsteps.rb
@@ -2,9 +2,10 @@
 require "highline/import"
 require 'dspace'
 require 'cli/dcollection'
+require 'cli/dconstants'
 
 DSpace.load
-DSpace.login ENV['USER']
+DSpace.login DConstants::LOGIN
 puts "\n"
 
 com_name =  'All Content'

--- a/symplectic/retract_deposit.rb
+++ b/symplectic/retract_deposit.rb
@@ -2,10 +2,11 @@
 require "highline/import"
 require 'dspace'
 require 'symplectic/ditem'
+require 'cli/dconstants'
 
 DSpace.load
 DSpace.context_renew
-DSpace.login ENV['USER']
+DSpace.login DConstants::LOGIN
 
 $dspace_url = 'http://oar-dev.princeton.edu'
 $symplectic_url = 'https://oaworkflow-dev.princeton.edu'

--- a/thesis_central/mapToMultipleCollections.rb
+++ b/thesis_central/mapToMultipleCollections.rb
@@ -1,7 +1,8 @@
 #!/usr/bin/env jruby
 require 'lumberjack'
+require 'cli/dconstants'
 
-account = "monikam"
+account = DConstants::LOGIN
 
 log_file = "#{ENV['DSPACE_HOME']}/log/map2Collections.log"
 $logger = Lumberjack::Logger.new("#{log_file}", :buffer_size => 0) # Open a new log file with INFO level
@@ -90,7 +91,7 @@ def map_all(year)
 end
 
 def test()
-  root = "88435/dsp019c67wm88m"
+  root = DConstants::SENIOR_THESIS_HANDLE
   colmap = make_colmap(root)
   i = DSpace.fromString('88435/dsp01gb19f854b')
 
@@ -100,4 +101,4 @@ def test()
 end
 
 
-map_all(2018)
+map_all(DConstants::DEFAULT_YEAR)

--- a/thesis_central/set_default_bitstream_read.rb
+++ b/thesis_central/set_default_bitstream_read.rb
@@ -1,15 +1,17 @@
 require 'cli/dspace.rb'
+require 'cli/dconstants'
+
 DSpace.load
 
 java_import org.dspace.eperson.Group
 
 
-DSpace.login 'monikam'
+DSpace.login DConstants::LOGIN
 
 def doit()
   mudd = Group.findByName(DSpace.context, 'SrTheses_Bitstream_Read_Mudd');
 
-  com = DSpace.fromString('88435/dsp019c67wm88m')
+  com = DSpace.fromString(DConstants::SENIOR_THESIS_HANDLE)
   for col in com.getCollections
     p  =  get_policies(col, 9)[0]
     p.setGroup mudd


### PR DESCRIPTION
Customized the DConstants class for Princeton-specific use (though now in hindsight, perhaps I should have customized the DConfig class instead?) I looked for repetitive constants in all scripts and centralized them, so if we need to change anything, it's in one place